### PR TITLE
fix lib exports according to readme usage guideance

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 import BlocksRenderer from "$lib/BlocksRenderer.svelte";
 
+export default BlocksRenderer;
 export { BlocksRenderer };


### PR DESCRIPTION
In readme, you mention the usage of `import BlocksRenderer from "$lib/BlocksRenderer.svelte";` but it does not work when you require the module from node_modules as you export only `{ BlocksRenderer }`.

PS : removing `export { BlocksRenderer };` will occurs breaking changes so I kept it.